### PR TITLE
feat: update dependencies and source for PHP 8.1+ compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,27 +24,26 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.1",
     "dflydev/fig-cookies": "^3.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "~1.0",
     "psr/http-server-handler": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "johnpbloch/wordpress-core-installer": "^2.0",
-    "superdav42/wordpress-core": "dev-master",
-    "symfony/polyfill-php80": "^1.22.1"
+    "superdav42/wordpress-core": "dev-master"
   },
   "require-dev": {
-    "rector/rector": "dev-main",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-    "friendsofphp/php-cs-fixer": "^2.18.2",
+    "rector/rector": "^2.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+    "friendsofphp/php-cs-fixer": "^3.0",
     "laminas/laminas-diactoros": "~2.2",
     "laminas/laminas-httphandlerrunner": "^1.3",
     "nyholm/psr7": "^1.4",
-    "phpstan/phpstan": "^0.12.80",
-    "phpunit/phpunit": "^9.3.8",
+    "phpstan/phpstan": "^2.0",
+    "phpunit/phpunit": "^10.0",
     "roave/security-advisories": "dev-master",
-    "wp-coding-standards/wpcs": "^2.3.0"
+    "wp-coding-standards/wpcs": "^3.0"
   },
   "suggest": {
     "rector/rector": "Modify code on-the-fly to use PSR functions."

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
 
     <!-- Configs -->
     <config name="minimum_supported_wp_version" value="4.7" />
-    <config name="testVersion" value="7.2-" />
+    <config name="testVersion" value="8.1-" />
 
     <!-- Rules -->
     <rule ref="WordPress-Core" />

--- a/rector.php
+++ b/rector.php
@@ -2,65 +2,41 @@
 
 declare(strict_types=1);
 
-use Rector\Core\Configuration\Option;
-use Rector\Php74\Rector\Property\TypedPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/wordpress/' );
 	define( 'WPINC', 'wp-includes' );
 	define( 'EP_NONE', 0 );
 }
-return static function ( ContainerConfigurator $container_configurator ): void {
-	// get parameters
-	$parameters = $container_configurator->parameters();
-	  $parameters->set(Option::SETS, [
-	      SetList::CODE_QUALITY,
-	      SetList::PHP_70,
-		  SetList::PHP_71,
-		  SetList::PHP_72,
-		  SetList::PHP_73,
-		  SetList::PHP_74,
-		  SetList::PHP_80
-	  ]);
-	$parameters->set(
-		Option::AUTOLOAD_PATHS,
-		array(
-			__DIR__ . '/wordpress',
-		)
-	);
-	// get services (needed for register a single rule)
-	$services = $container_configurator->services();
-	// register a single rule
-	$services->set( \WordPressPsr\Rector\NoExit::class );
-	$services->set( \WordPressPsr\Rector\NewHeaderFunction::class );
-	$services->set( \WordPressPsr\Rector\NewCookieFunction::class );
-	$services->set( \WordPressPsr\Rector\NewHeaderRemoveFunction::class );
-//	$services->set( \Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector::class );
-\Rector\Php70\Rector\ClassMethod\Php4ConstructorRector::class;
-	$parameters->set( Option::IMPORT_DOC_BLOCKS, false );
-	$parameters->set( Option::AUTO_IMPORT_NAMES, true );
-	$parameters->set(
-		Option::SKIP,
-		array(
-			__DIR__ . '/wordpress/wp-includes/SimplePie/*',
-			__DIR__ . '/wordpress/wp-includes/sodium_compat/*',
-			__DIR__ . '/wordpress/wp-includes/class-json.php',
-			__DIR__ . '/wordpress/wp-content/plugins/akismet/class.akismet-cli.php',
-			__DIR__ . '/wordpress/wp-includes/class-wp-feed-cache.php',
-			__DIR__ . '/wordpress/wp-includes/class-wp-simplepie-file.php',
-			__DIR__ . '/wordpress/wp-includes/class-wp-simplepie-sanitize-kses.php',
-			__DIR__ . '/wordpress/wp-includes/class-wp-simplepie-file.php',
-			__DIR__ . '/wordpress/wp-includes/class-wp-feed-cache.php',
-			__DIR__ . '/wordpress/wp-admin/includes/noop.php',
-		)
-	);
 
-	$parameters->set(
-		Option::PATHS,
-		array(
-			__DIR__ . '/wordpress/',
-		)
-	);
-};
+return RectorConfig::configure()
+	->withPaths( array(
+		__DIR__ . '/wordpress/',
+	) )
+	->withAutoloadPaths( array(
+		__DIR__ . '/wordpress',
+	) )
+	->withSets( array(
+		SetList::CODE_QUALITY,
+		LevelSetList::UP_TO_PHP_82,
+	) )
+	->withRules( array(
+		\WordPressPsr\Rector\NoExit::class,
+		\WordPressPsr\Rector\NewHeaderFunction::class,
+		\WordPressPsr\Rector\NewCookieFunction::class,
+		\WordPressPsr\Rector\NewHeaderRemoveFunction::class,
+	) )
+	->withImportNames( importDocBlockNames: false )
+	->withSkip( array(
+		__DIR__ . '/wordpress/wp-includes/SimplePie/*',
+		__DIR__ . '/wordpress/wp-includes/sodium_compat/*',
+		__DIR__ . '/wordpress/wp-includes/class-json.php',
+		__DIR__ . '/wordpress/wp-content/plugins/akismet/class.akismet-cli.php',
+		__DIR__ . '/wordpress/wp-includes/class-wp-feed-cache.php',
+		__DIR__ . '/wordpress/wp-includes/class-wp-simplepie-file.php',
+		__DIR__ . '/wordpress/wp-includes/class-wp-simplepie-sanitize-kses.php',
+		__DIR__ . '/wordpress/wp-admin/includes/noop.php',
+	) );

--- a/src/Rector/NewCookieFunction.php
+++ b/src/Rector/NewCookieFunction.php
@@ -5,7 +5,7 @@ namespace WordPressPsr\Rector;
 use PhpParser\Node;
 
 use PhpParser\Node\Expr\FuncCall;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/src/Rector/NewHeaderFunction.php
+++ b/src/Rector/NewHeaderFunction.php
@@ -5,7 +5,7 @@ namespace WordPressPsr\Rector;
 use PhpParser\Node;
 
 use PhpParser\Node\Expr\FuncCall;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/src/Rector/NewHeaderRemoveFunction.php
+++ b/src/Rector/NewHeaderRemoveFunction.php
@@ -5,7 +5,7 @@ namespace WordPressPsr\Rector;
 use PhpParser\Node;
 
 use PhpParser\Node\Expr\FuncCall;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/src/Rector/NoExit.php
+++ b/src/Rector/NoExit.php
@@ -6,7 +6,7 @@ namespace WordPressPsr\Rector;
 
 use PhpParser\Node;
 use PhpParser\Node\Name;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 


### PR DESCRIPTION
## Summary

- Bumps minimum PHP requirement from \`>=7.1\` to \`>=8.1\` (PHP 7.x is EOL)
- Removes \`symfony/polyfill-php80\` (redundant on PHP 8.1+)
- Migrates all dev tooling to current major versions
- Migrates \`rector.php\` from deprecated \`ContainerConfigurator\` API to \`RectorConfig\` fluent API
- Fixes all four custom Rector rules: \`Rector\Core\Rector\AbstractRector\` → \`Rector\Rector\AbstractRector\`

## Changes

| File | What changed |
|------|-------------|
| \`composer.json\` | PHP \`>=8.1\`, remove polyfill, rector \`^2.0\`, php-cs-fixer \`^3.0\`, phpstan \`^2.0\`, phpunit \`^10.0\`, wpcs \`^3.0\`, dealerdirect \`^1.0\` |
| \`rector.php\` | Full rewrite to \`RectorConfig::configure()\` fluent API; sets \`LevelSetList::UP_TO_PHP_82\` |
| \`src/Rector/NoExit.php\` | Fix \`AbstractRector\` namespace |
| \`src/Rector/NewHeaderFunction.php\` | Fix \`AbstractRector\` namespace |
| \`src/Rector/NewCookieFunction.php\` | Fix \`AbstractRector\` namespace |
| \`src/Rector/NewHeaderRemoveFunction.php\` | Fix \`AbstractRector\` namespace |
| \`phpcs.xml\` | Update \`testVersion\` from \`7.2-\` to \`8.1-\` |

## Runtime Testing

- **Risk classification:** Low — configuration and tooling changes only; no runtime application logic modified
- **Testing level:** self-assessed
- **Verification:** All changes are dependency version bumps and API migrations matching the documented Rector 1.0+ migration guide. No application behaviour is altered.

Closes #4