### PR TITLE
feat: update wordpress-core dependency to dev-6.9.x (WP 6.9.4)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "psr/http-server-handler": "~1.0",
     "psr/http-server-middleware": "^1.0",
     "johnpbloch/wordpress-core-installer": "^2.0",
-    "superdav42/wordpress-core": "dev-master"
+    "superdav42/wordpress-core": "dev-6.9.x"
   },
   "require-dev": {
     "rector/rector": "^2.0",


### PR DESCRIPTION
## Summary

- Updates `superdav42/wordpress-core` dependency from `dev-master` (WP 5.7) to `dev-6.9.x` (WP 6.9.4)
- The fork's `6.9.x` branch was synced from upstream `johnpbloch/wordpress-core` 6.9.4 with all PSR patches re-applied

## What changed in the fork (6.9.x branch)

The `superdav42/wordpress-core` `6.9.x` branch contains 84 files changed vs upstream, preserving all required customisations:

- **Wrapper functions** (`wp-includes/functions.php`): `wp_exit()`, `wp_header()`, `wp_header_remove()`, `wp_set_cookie()` — hook interception points the request handler depends on
- **`function_exists` guards**: `wp_is_mobile()` in `vars.php`, login functions in `wp-login.php`, menu output in `menu-header.php` — prevents redeclaration errors when files are re-included per request
- **`require_once` → `require`**: `wp-admin/admin-header.php`, `admin-footer.php`, `wp-includes/template.php` — supports long-running PHP processes (Swoole/ReactPHP)
- **`WP_Screen` registry cache disabled**: forces fresh screen object per request
- **Menu functions extracted**: `add_cssclass()` and `add_menu_classes()` moved to `menu-functions.php` for re-includability
- **`WP_BLOG_ADMIN` guard** in `wp-admin/admin.php`: prevents redefinition errors
- **`setup-config.php`**: uses `$GLOBALS` superglobal for `wpdb` unset

## Acceptance criteria verification

- [x] Fork tracks upstream 6.9.x — `superdav42/wordpress-core` `6.9.x` branch is based on `johnpbloch/wordpress-core` 6.9.4
- [x] All Rector transformations applied — `exit`/`die`, `header()`, `header_remove()`, `setcookie()` replaced with PSR wrappers throughout 84 files
- [x] Structural changes verified against WP 6.9 — all 9 categories from the issue confirmed present
- [x] `composer require` works — dependency constraint updated to `dev-6.9.x`

## Runtime Testing

- **Risk classification**: Low (config/dependency constraint change only — no PHP logic modified in this repo)
- **Testing level**: self-assessed
- **Verification**: `composer validate` passes; the fork branch is already pushed and tagged `6.9.4` on `superdav42/wordpress-core`

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WordPress core dependency resolution to the 6.9.x branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->