### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
@@ -36,7 +36,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions to Node.js 24 compatible versions ahead of the June 2, 2026 forced migration deadline.

### Changes

- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/cache@v4` → `actions/cache@v5`

`shivammathur/setup-php@v2` is already on Node 24 (v2.37.0) — no change needed.
No `softprops/action-gh-release` present in this repo's workflows.

### Verification

After merging, trigger a CI run and confirm no Node.js 20 deprecation warnings appear in the workflow annotations.

Resolves #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow dependencies to latest versions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->